### PR TITLE
docs: access control

### DIFF
--- a/content/en/architecture/access-control/_index.en.md
+++ b/content/en/architecture/access-control/_index.en.md
@@ -1,0 +1,41 @@
+---
+title: "Access Control Definitions"
+linkTitle: "Access Control"
+type: "architecture"
+weight: 20
+draft: false
+lang: "en"
+date: 2025-05-29
+---
+
+<gcds-alert alert-role="danger" container="full" heading="Avis de traduction" hide-close-btn="true" hide-role-icon="false" is-fixed="false" class="hydrated mb-400">
+<gcds-text>Veuillez noter que ce document est actuellement en cours de développement actif et pourrait être sujet à des révisions. Une fois terminé, il sera entièrement traduit en français et mis à disposition dans sa version finale.</gcds-text>
+</gcds-alert>
+
+Access control is implemented according to the principle of least privilege. This section describes how that is done in Aurora Kubernetes clusters as well as the underlying Cloud Service Providers (CSPs). These procedures are reviewed multiple times a year, whenever there are updates to the underlying APIs or organisational processes.
+
+Aurora platform components that access or provide data are identified through non-human accounts such as Kubernetes Service Accounts and Microsoft Entra workload identities. These accounts are granted the minimum necessary sets of permissions for each component's intended function.
+
+Microsoft Entra ID is the centralized identity provider, with one account per human user. Each account has access to one or more user roles that align with the following high-level definitions:
+
+## Solution Builder
+Solution Builders design, develop, deploy, and operate solutions that run on Aurora. They require access to Kubernetes Resources and CustomResources. Typically this access is restricted to a Kubernetes Namespace on one or more Clusters.
+
+Solution Builders may also require access to CSP resources such as managed databases and storage accounts. This is outside the scope of Aurora's access control and is established according to the processes of the corresponding Infrastructure-as-a-Service service lines.
+
+## Platform Operator
+Platform Operators ensure the continual operation of one or more Aurora platforms. This requires read access to most platform resources, excluding confidential information such as Secrets. This also requires write access for common and low-impact remediation activities, such as restarting specific types of CSP resources. 
+
+> Platform Operator write access is very limited. Whenever possible, changes to Aurora platforms are effected via Infrastructure/Configuration-as-Code and corresponding automated CI/CD processes. Higher impact manual remediation requires escalation to the Platform Administrator role.
+
+## Platform Administrator
+Platform Administrators have full access to the Kubernetes clusters and other CSP resources comprising one or more Aurora platforms. This role is only accessed via tracked and justified privilege escalation processes. 
+
+It is invoked in order to:
+- Perform planned maintenance that requires major manual changes. These changes must first be verified using the Platform Developer role in the appropriate testing environment.
+- Resolve urgent security and/or operational incidents, including on an on-call basis.
+
+## Platform Developer
+Platform Developers design, develop, and implement one or more Aurora platforms. They have full access to the corresponding platform development environments in order to create, improve, and extend new platform features, as well as to validate platform functionality and configuration changes. 
+
+> These platform development environments exist **only** for this purpose: no Solution Builder workloads run on these environments, and no Solution Builders access them.

--- a/content/en/architecture/access-control/azure.en.md
+++ b/content/en/architecture/access-control/azure.en.md
@@ -1,0 +1,53 @@
+---
+title: "Azure"
+linkTitle: "Azure"
+type: "architecture"
+weight: 10
+draft: false
+lang: "en"
+date: 2025-05-29
+---
+
+<gcds-alert alert-role="danger" container="full" heading="Avis de traduction" hide-close-btn="true" hide-role-icon="false" is-fixed="false" class="hydrated mb-400">
+<gcds-text>Veuillez noter que ce document est actuellement en cours de développement actif et pourrait être sujet à des révisions. Une fois terminé, il sera entièrement traduit en français et mis à disposition dans sa version finale.</gcds-text>
+</gcds-alert>
+
+Aurora platform components that communicate over Azure may have associated [Microsoft Entra workload identities](https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-overview) such as applications, service principals, and managed identities. Permissions, such as available APIs and tokens, are assigned to each individual identity according to the minimum requirement for the functionality of the component.
+
+Azure access control for Aurora's human users is implemented in the following ways:
+
+## Solution Builder
+
+Solution Builders are members of one or more [Microsoft Entra groups](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-manage-groups) corresponding to their team. The Azure resources they have access to are determined by that team in collaboration with any relevant Infrastructure-as-a-Service service lines.
+
+## Platform Operator
+
+Platform Operators have access to a custom role within the Azure management groups corresponding to one or more Aurora platforms.
+
+This custom role has the following permissions:
+
+| Component                   | Action            | Purpose                                            | 
+| :-------------------------- | :---------------- | :------------------------------------------------- | 
+| All                         | Read              | Gather information for troubleshooting             | 
+| Virtual Routers             | Learned Routes    | Get learned BGP routes from Azure route servers    | 
+| Virtual Routers             | Advertised Routes | Get advertised BGP routes from Azure route servers | 
+| Virtual Machines            | Start             | Start virtual machines (VMs)                       | 
+| "                           | Power-Off         | Temporarily shut down VMs                          | 
+| "                           | Deallocate        | Shut down and pause billing for VMs                | 
+| "                           | Restart           | Reboot virtual machines                            | 
+| Virtual Machine Scale Sets  | Start             | Start Virtual Machine Scale Set (VMSS) instances   | 
+| "                           | Power-Off         | Temporarily shut down VMSS instances               | 
+| "                           | Deallocate        | Shut down and pause billing for VMSS instances     | 
+| "                           | Restart           | Reboot VMSS instances                              | 
+| Managed Clusters            | Abort             | Cancel the last operation on AKS clusters          | 
+| Managed Cluster Agent Pools | Abort             | Cancel the last operation on AKS node pools        | 
+
+## Platform Administrator
+
+The Platform Administrator identity can be accessed by designated personnel by using [Microsoft Entra Privileged Identity Management](https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure) to activate their membership in the corresponding Microsoft Entra group. Activation requires submitting a justification, a time duration, and a reference to a support, maintenance, or incident ticket. All members of this group are notified by email when such an activation occurs, and activation records are available for audit in Azure.
+
+This grants access to the built-in Azure roles [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) and [Role Based Access Control Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#role-based-access-control-administrator) within the management groups corresponding to one or more Aurora platforms. 
+
+## Platform Developer
+
+The Platform Developer identity has the same roles as the Platform Administrator, but only within specific Aurora platform development subscriptions. To facilitate rapid development and testing, privilege escalation is not required within these environments.

--- a/content/en/architecture/access-control/kubernetes.en.md
+++ b/content/en/architecture/access-control/kubernetes.en.md
@@ -1,0 +1,41 @@
+---
+title: "Kubernetes"
+linkTitle: "Kubernetes"
+type: "architecture"
+weight: 1
+draft: false
+lang: "en"
+date: 2025-05-29
+---
+
+<gcds-alert alert-role="danger" container="full" heading="Avis de traduction" hide-close-btn="true" hide-role-icon="false" is-fixed="false" class="hydrated mb-400">
+<gcds-text>Veuillez noter que ce document est actuellement en cours de développement actif et pourrait être sujet à des révisions. Une fois terminé, il sera entièrement traduit en français et mis à disposition dans sa version finale.</gcds-text>
+</gcds-alert>
+
+Kubernetes offers [Roles and ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) which define access and [RoleBindings and ClusterRoleBindings](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) which bind Roles and ClusterRoles to an OAuth identity. This identity be an individual user or user group from an integrated OAuth provider (in our case Microsoft Entra ID) or a [Kubernetes ServiceAccount](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/).
+
+Aurora platform component access control is managed using Kubernetes ServiceAccounts in each component's Namespace. Each ServiceAccount has its own Role or ClusterRole defining the exact rules necessary for the corresponding component's function.
+
+Human user access control is implemented across all Aurora Kubernetes clusters in the following ways:
+
+## Solution Builder
+
+A custom [`solution-builder` ClusterRole](https://github.com/gccloudone-aurora/aurora-platform-charts/blob/main/stable/aurora-platform/charts/aurora-core/templates/rbac/solution-builder.yaml) defines the minimum permissions necessary for application development and operation on Kubernetes. The label `rbac.ssc-spc.gc.ca/aggregate-to-solution-builder: "true"` permits component-specific Solution Builder ClusterRoles to be defined separately and [aggregated](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) into this role. ([Example](https://github.com/gccloudone-aurora/aurora-platform-charts/blob/main/stable/aurora-platform/charts/aurora-core/templates/prometheus/rbac.yaml))
+
+A RoleBinding in each Solution Builder namespace binds this ClusterRole to the Microsoft Entra group designated for the Kubernetes application developers/operators of that Solution Builder team.
+
+## Platform Operator
+
+Two custom ClusterRoles are defined for Platform Operators: [`platform-operator-view`](https://github.com/gccloudone-aurora/aurora-platform-charts/blob/main/stable/aurora-platform/charts/aurora-core/templates/rbac/platform-operator-view.yaml) for read access and [`platform-operator-maintenance'](https://github.com/gccloudone-aurora/aurora-platform-charts/blob/main/stable/aurora-platform/charts/aurora-core/templates/rbac/platform-operator-maintenance.yaml) for write access. ClusterRole aggregation to these roles further defines read and write access to specific platform components.
+
+A ClusterRoleBinding binds these ClusterRoles to the Microsoft Entra group designated for the day-to-day activities of the cluster's Platform Operators.
+
+## Platform Administrator
+
+Platform Administrators correspond to the [default User-facing Kubernetes role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) `cluster-admin`. This role is bound to a specific Microsoft Entra ID group whose membership is activated via [Microsoft Entra Privileged Identity Management](https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure). 
+
+Activation requires submitting a justification, a time duration, and a reference to a support, maintenance, or incident ticket. Once the alloted time has expired, the Microsoft Entra ID [access token](https://learn.microsoft.com/en-us/entra/identity/users/users-revoke-access#access-tokens-and-refresh-tokens) required for this privileged role is no longer issued or refreshed. 
+
+## Platform Developer
+
+Platform Developers also correspond to the `cluster-admin` default role. Unlike the Platform Administrator, this role is not time-bound. However, this role is only defined and accessible on clusters designated for developing and testing Aurora platform infrastructure.


### PR DESCRIPTION
Adds some initial access control documentation to the Architecture section. I've taken the approach of a high-level definition of roles at the index, with subsections for how those roles are implemented in different environments (starting with Kubernetes and Azure. Later there could be a GCP and AWS section and so on). 

Notes:
- I considered creating a Security subsection in Architecture to move this all under. But whether such deeper nesting makes sense depends on how much other content will be there. I think we can revisit that as we add more content.
- The Azure section is based on the plan for the Cloud Native Platform. We may need to update this further or add new information for our current Azure environment.
- The content in general is based on the relevant sections of the CNP 2.0 architectural plan and intended to convey the same information, except for some outstanding recommendations which I've converted to Jira tickets. To keep concise and minimize future maintenance, I've pared down the implementation details by pointing to upstream (Kubernetes, Azure) documentation as well as the Aurora source code where possible. That said, it can be tricky to strike the balance between "easy overview" and "thorough explanation", so let me know if I've omitted too much. 