### PR TITLE
fix: Restore lightbox functionality

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,16 @@
+<!-GLightbox -->
+<script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+<script>
+  const style = document.createElement('style');
+  style.innerHTML = `
+    .glightbox-container.glightbox-custom-white-bg img {
+      background: white !important;
+    }
+  `;
+  document.head.appendChild(style);
+  const lightbox = GLightbox({
+    openEffect: 'zoom',
+    closeEffect: 'fade',
+    skin: 'custom-white-bg'
+  });
+</script>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css">


### PR DESCRIPTION
When I cleaned up the Aurora site to align with the updated theme, I removed the override of `baseof.html` which inadvertently removed the lightbox functionality.

This MR brings it back by utilizing the hooks so that we don't need to override the full `baseof.html` file. 